### PR TITLE
2 feature GitHub webhook update

### DIFF
--- a/domain/github.go
+++ b/domain/github.go
@@ -1,6 +1,6 @@
 package domain
 
-type RegisterGithubWebhookDto struct {
+type RequestGithubWebhookDto struct {
 	Owner     string
 	Repo      string
 	Token     string

--- a/exception/consts.go
+++ b/exception/consts.go
@@ -2,4 +2,7 @@ package exception
 
 import "errors"
 
-var AlreadyHookExistsError = errors.New("Hook is already exists ")
+var (
+	AlreadyHookExistsError = errors.New("Hook is already exists ")
+	NotFoundHooks          = errors.New("Not Found Hooks")
+)

--- a/service/github/github_service.go
+++ b/service/github/github_service.go
@@ -10,7 +10,8 @@ import (
 )
 
 type GitService interface {
-	RegisterWebhookforJenkins(ctx context.Context, hookDto domain.RegisterGithubWebhookDto) error
+	RegisterWebhookForJenkins(ctx context.Context, hookDto domain.RequestGithubWebhookDto) error
+	ModifyWebhookForJenkins(ctx context.Context, hookDto domain.RequestGithubWebhookDto) error
 }
 
 var (

--- a/service/github/github_service_impl.go
+++ b/service/github/github_service_impl.go
@@ -14,7 +14,7 @@ type gitServiceImpl struct {
 
 var _ GitService = (*gitServiceImpl)(nil)
 
-// RegisterWebhookforJenkins is a function that registers a webhook in a GitHub repository for  Jenkins. Since we're using HTTPS, insecure_ssl is set to false.
+// RegisterWebhookForJenkins is a function that registers a webhook in a GitHub repository for  Jenkins. Since we're using HTTPS, insecure_ssl is set to false.
 // Also, if at least one webhook is already registered, registration will fail.
 func (g gitServiceImpl) RegisterWebhookForJenkins(ctx context.Context, hookDto domain.RequestGithubWebhookDto) error {
 	err, _ := g.isExistWebhook(ctx, hookDto.Owner, hookDto.Repo)
@@ -40,7 +40,7 @@ func (g gitServiceImpl) RegisterWebhookForJenkins(ctx context.Context, hookDto d
 	return nil
 }
 
-// ModifyWebhookForJenkins is used to change the URL of a webhook. The data required in the request is the same as RegisterWebhookforJenkins.
+// ModifyWebhookForJenkins is used to change the URL of a webhook. The data required in the request is the same as RegisterWebhookForJenkins.
 func (g gitServiceImpl) ModifyWebhookForJenkins(ctx context.Context, hookDto domain.RequestGithubWebhookDto) error {
 	_, id := g.isExistWebhook(ctx, hookDto.Owner, hookDto.Repo)
 	if id == nil {

--- a/service/github/github_service_impl.go
+++ b/service/github/github_service_impl.go
@@ -40,6 +40,7 @@ func (g gitServiceImpl) RegisterWebhookForJenkins(ctx context.Context, hookDto d
 	return nil
 }
 
+// ModifyWebhookForJenkins is used to change the URL of a webhook. The data required in the request is the same as RegisterWebhookforJenkins.
 func (g gitServiceImpl) ModifyWebhookForJenkins(ctx context.Context, hookDto domain.RequestGithubWebhookDto) error {
 	_, id := g.isExistWebhook(ctx, hookDto.Owner, hookDto.Repo)
 	if id == nil {


### PR DESCRIPTION
## DESCRIPTION

## MERGE INFO

### ISSUE NUMBER(JIRA OR GIT)
- #2 

### TARGET
- [x] dev
- [ ] master(release)

### TYPE
- [x] FEATURE
- [ ] BUG
- [ ] CI/CD
- [ ] DOC

## PROBLEM INFO

### PROBLEM
- webhook 등록 후, 업데이트를 하는 기능이 없음

### SOLUTIONS
- 관련 기능 구현

### CHANGE LOG

업데이트 기능을 구현함. 여기서 webhook은 하나만 유지되게 만들어져 있음
```go
// ModifyWebhookForJenkins is used to change the URL of a webhook. The data required in the request is the same as RegisterWebhookForJenkins.
func (g gitServiceImpl) ModifyWebhookForJenkins(ctx context.Context, hookDto domain.RequestGithubWebhookDto) error {
	_, id := g.isExistWebhook(ctx, hookDto.Owner, hookDto.Repo)
	if id == nil {
		return exception.NotFoundHooks
	}
	hook, _, err := g.client.Repositories.GetHook(ctx, hookDto.Owner, hookDto.Repo, *id)
	if err != nil {
		return err
	}
	hook.URL = github.String(hookDto.TargetUrl)
	_, _, err = g.client.Repositories.EditHook(ctx, hookDto.Owner, hookDto.Repo, *id, hook)
	if err != nil {
		return err
	}
	return nil
}
```


### ETC
modify 하는 기능외에 변수명 및 함수명 수정을 했습니다.