### PR TITLE
9 feature delete jenkins job

### DIFF
--- a/service/jenkins/jenkins_service.go
+++ b/service/jenkins/jenkins_service.go
@@ -9,7 +9,7 @@ import (
 
 type JenkinsService interface {
 	CreateJob(jobName, folderName, content *string) (*gojenkins.Job, error)
-	UpdateJob(ctx context.Context, jobName, folderName, content *string) (*gojenkins.Job, error)
+	UpdateJob(ctx context.Context, jobName, folderName, content *string) error
 	DeleteJob(ctx context.Context, jobName, folderName *string) error
 }
 

--- a/service/jenkins/jenkins_service.go
+++ b/service/jenkins/jenkins_service.go
@@ -10,6 +10,7 @@ import (
 type JenkinsService interface {
 	CreateJob(jobName, folderName, content *string) (*gojenkins.Job, error)
 	UpdateJob(ctx context.Context, jobName, folderName, content *string) (*gojenkins.Job, error)
+	DeleteJob(ctx context.Context, jobName, folderName *string) error
 }
 
 func NewJenkinsService(jenkinsCOnfig *config.Jenkins) JenkinsService {

--- a/service/jenkins/jenkins_service_impl.go
+++ b/service/jenkins/jenkins_service_impl.go
@@ -26,3 +26,16 @@ func (j *jenkinsServiceImpl) UpdateJob(ctx context.Context, jobName, folderName,
 	_ = j.jenkins.UpdateJob(ctx, jobPath, *content)
 	return nil, nil
 }
+
+// DeleteJob implements JenkinsService.
+func (j *jenkinsServiceImpl) DeleteJob(ctx context.Context, jobName *string, folderName *string) error {
+	job, err := j.jenkins.GetJob(ctx, *jobName, *folderName)
+	if err != nil {
+		return err
+	}
+	_, err = job.Delete(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/service/jenkins/jenkins_service_impl.go
+++ b/service/jenkins/jenkins_service_impl.go
@@ -21,10 +21,16 @@ func (j *jenkinsServiceImpl) CreateJob(jobName, folderName, content *string) (*g
 }
 
 // UpdateJob implements JenkinsService.
-func (j *jenkinsServiceImpl) UpdateJob(ctx context.Context, jobName, folderName, content *string) (*gojenkins.Job, error) {
-	jobPath := *folderName + "/" + *jobName
-	_ = j.jenkins.UpdateJob(ctx, jobPath, *content)
-	return nil, nil
+func (j *jenkinsServiceImpl) UpdateJob(ctx context.Context, jobName, folderName, content *string) error {
+	job, err := j.jenkins.GetJob(ctx, *jobName, *folderName)
+	if err != nil {
+		return err
+	}
+	err = job.UpdateConfig(ctx, *content)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // DeleteJob implements JenkinsService.


### PR DESCRIPTION
## DESCRIPTION

## MERGE INFO

### ISSUE NUMBER(JIRA OR GIT)
- #9 

### TARGET
- [x] dev
- [ ] master(release)

### TYPE
- [x] FEATURE
- [ ] BUG
- [ ] CI/CD
- [ ] DOC

## PROBLEM INFO

### PROBLEM
jenkins job을 삭제할 수 있는 기능이 없음

### SOLUTIONS
jenkins job을 삭제하는 기능 구현

### CHANGE LOG
```go
// DeleteJob implements JenkinsService.
func (j *jenkinsServiceImpl) DeleteJob(ctx context.Context, jobName *string, folderName *string) error {
	job, err := j.jenkins.GetJob(ctx, *jobName, *folderName)
	if err != nil {
		return err
	}
	_, err = job.Delete(ctx)
	if err != nil {
		return err
	}
	return nil
}
```

### ETC

updateJob의 코드도 약간 수정함
```go
func (j *jenkinsServiceImpl) UpdateJob(ctx context.Context, jobName, folderName, content *string) error {
	job, err := j.jenkins.GetJob(ctx, *jobName, *folderName)
	if err != nil {
		return err
	}
	err = job.UpdateConfig(ctx, *content)
	if err != nil {
		return err
	}
	return nil
}
```
